### PR TITLE
Chunk writing

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -113,9 +113,9 @@ pub enum SclsError {
     #[error("writer builder is missing its required slot number parameter")]
     WriterBuilderMissingSlotNo,
 
-    /// Entry attribute length overflow
-    #[error("entry key/value length overflow")]
-    EntryOverflow,
+    /// Overflow error when writing to the wire format
+    #[error("{0} length overflow in wire format")]
+    WireLengthOverflow(String),
 
     /// Inconsistent entry key lengths within a namespace
     #[error("inconsistent entry key length in {namespace}: expected {expected}, found {found}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,6 +112,18 @@ pub enum SclsError {
     /// Writer builder missing required slot number parameter
     #[error("writer builder is missing its required slot number parameter")]
     WriterBuilderMissingSlotNo,
+
+    /// Entry attribute length overflow
+    #[error("entry key/value length overflow")]
+    EntryOverflow,
+
+    /// Inconsistent entry key lengths within a namespace
+    #[error("inconsistent entry key length in {namespace}: expected {expected}, found {found}")]
+    InconsistentKeyLength {
+        namespace: String,
+        expected: usize,
+        found: usize,
+    },
 }
 
 /// Convenience type alias for Results with SclsError.

--- a/src/error.rs
+++ b/src/error.rs
@@ -124,6 +124,20 @@ pub enum SclsError {
         expected: usize,
         found: usize,
     },
+
+    /// Attempted to write non-monotonic namespace
+    ///
+    /// Note, this is effectively equivalent to [`SclsError::NamespaceDisordered`]. We maintain the
+    /// distinction because they occur under semantically distinct operations.
+    #[error("Namespaces are not in bytewise order: previous \"{previous}\", found \"{found}\"")]
+    NonMonotonicNamespace { previous: String, found: String },
+
+    /// Attempted to write non-strictly monotonic entry key
+    ///
+    /// Note, this is similar to [`SclsError::KeysDisordered`]. We maintain the distinction because
+    /// they occur under semantically distinct operations.
+    #[error("Entry keys are not strictly lexicographically increasing in {namespace}")]
+    NonStrictlyMonotonicKeys { namespace: String },
 }
 
 /// Convenience type alias for Results with SclsError.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -246,22 +246,13 @@ impl<W: Write> SclsWriter<W> {
             }
         }
 
-        // Check and update (if necessary) key entry state
-        match &self.prev_ns_entry_key {
-            None => {
-                self.prev_ns_entry_key = Some(key.to_vec());
-            }
-
-            Some(prev_key) => {
-                // Strict monotonicity check
-                if prev_key.as_slice() >= key {
-                    return Err(SclsError::NonStrictlyMonotonicKeys {
-                        namespace: namespace.to_string(),
-                    });
-                }
-
-                self.prev_ns_entry_key = Some(key.to_vec());
-            }
+        // Check key monotonicity (without updating state yet)
+        if let Some(prev_key) = &self.prev_ns_entry_key
+            && prev_key.as_slice() >= key
+        {
+            return Err(SclsError::NonStrictlyMonotonicKeys {
+                namespace: namespace.to_string(),
+            });
         }
 
         // Flush any existing chunk that's reached the size limit
@@ -277,7 +268,12 @@ impl<W: Write> SclsWriter<W> {
             self.current_chunk = Some(ChunkState::new());
         }
 
-        self.update_chunk(key, value)
+        self.update_chunk(key, value)?;
+
+        // Only advance key state after successful write
+        self.prev_ns_entry_key = Some(key.to_vec());
+
+        Ok(())
     }
 
     /// Update the chunk that is currently being built with the next entry.
@@ -325,6 +321,14 @@ impl<W: Write> SclsWriter<W> {
             }
         };
 
+        // Compute and check entry length
+        let entry_len = u32::try_from(
+            key.len()
+                .checked_add(value.len())
+                .ok_or(SclsError::WireLengthOverflow("entry".into()))?,
+        )
+        .map_err(|_| SclsError::WireLengthOverflow("entry".into()))?;
+
         // Compute entry digest
         let entry_digest = Blake2b::new_leaf()
             .update(namespace.as_bytes())
@@ -337,13 +341,6 @@ impl<W: Write> SclsWriter<W> {
         ns_state.merkle.add_leaf(entry_digest);
 
         // Serialise entry
-        let entry_len = u32::try_from(
-            key.len()
-                .checked_add(value.len())
-                .ok_or(SclsError::WireLengthOverflow("entry".into()))?,
-        )
-        .map_err(|_| SclsError::WireLengthOverflow("entry".into()))?;
-
         chunk.entries += 1;
         chunk.payload.extend_from_slice(&entry_len.to_be_bytes());
         chunk.payload.extend_from_slice(key);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 
 use crate::error::{Result, SclsError};
 use crate::hash::{Blake2b, MerkleTree};
-use crate::records::Header;
+use crate::records::{ChunkFormat, Header, RecordType};
 
 /// Default tool name.
 pub const DEFAULT_TOOL: &str = "cardano-scrawls";
@@ -138,8 +138,8 @@ struct ChunkState {
     /// Serialised entries payload
     payload: Vec<u8>,
 
-    /// Chunk digest
-    digest: Blake2b,
+    /// Chunk digest hasher
+    hasher: Blake2b,
 
     /// Number of entries in the chunk
     entries: u32,
@@ -149,7 +149,7 @@ impl ChunkState {
     fn new() -> Self {
         Self {
             payload: Vec::new(),
-            digest: Blake2b::new_raw(),
+            hasher: Blake2b::new_raw(),
             entries: 0,
         }
     }
@@ -185,6 +185,7 @@ pub struct SclsWriter<W> {
     chunk_seqno: u64,
 
     /// Chunk state
+    // NOTE Reset this to `None` whenever a chunk is flushed
     current_chunk: Option<ChunkState>,
 
     /// Namespace state
@@ -237,17 +238,21 @@ impl<W: Write> SclsWriter<W> {
         //
         // ChunkState::write - writer (SclsWriter.output), seqno (SclsWriter.chunk_seqno), namespace (SclsWriter.prev_namespace)
         // OR SclsWriter::flush_chunk - chunk state [cleaner]
-        // - [ ] Discharge chunk wire format to writer
-        // - [ ] Increment chunk_seqno
-        // - [ ] Update ns_state[namespace].{chunks, entries}
-        // - [ ] Reset current_chunk to None
+        // - [x] Discharge chunk wire format to writer
+        // - [x] Increment chunk_seqno
+        // - [x] Update ns_state[namespace].{chunks, entries}
+        // - [x] Reset current_chunk to None
         //
-        //  NOTE: Finalise will have to call flush_chunk to empty what's left in the buffer
+        // [x] NOTE: Finalise will have to call flush_chunk to empty what's left in the buffer
 
         self.update_chunk(key, value)
     }
 
     /// Update the chunk that is currently being built with the next entry.
+    ///
+    /// Note that this _must_ be called when the necessary state is available. Namely:
+    /// [`SclsWriter::prev_namespace`], [`SclsWriter::current_chunk`] and the respective namespace
+    /// entry in [`SclsWriter::ns_state`].
     ///
     /// # Errors
     ///
@@ -282,7 +287,8 @@ impl<W: Write> SclsWriter<W> {
 
             None => {
                 // Checked truncation
-                let key_len = u32::try_from(key.len()).map_err(|_| SclsError::EntryOverflow)?;
+                let key_len = u32::try_from(key.len())
+                    .map_err(|_| SclsError::WireLengthOverflow("entry key".into()))?;
                 ns_state.key_len = Some(key_len);
             }
         };
@@ -295,16 +301,16 @@ impl<W: Write> SclsWriter<W> {
             .as_digest();
 
         // Update chunk digest and namespace Merkle tree
-        chunk.digest.update(entry_digest.as_bytes());
+        chunk.hasher.update(entry_digest.as_bytes());
         ns_state.merkle.add_leaf(entry_digest);
 
         // Serialise entry
         let entry_len = u32::try_from(
             key.len()
                 .checked_add(value.len())
-                .ok_or(SclsError::EntryOverflow)?,
+                .ok_or(SclsError::WireLengthOverflow("entry".into()))?,
         )
-        .map_err(|_| SclsError::EntryOverflow)?;
+        .map_err(|_| SclsError::WireLengthOverflow("entry".into()))?;
 
         chunk.entries += 1;
         chunk.payload.extend_from_slice(&entry_len.to_be_bytes());
@@ -314,17 +320,71 @@ impl<W: Write> SclsWriter<W> {
         Ok(())
     }
 
-    // TODO: Flush chunk
-    // len_record (4) = 1 + 8 + 1 + 4 + len_ns + 4 + len(entries) + 4 + 28
-    // type byte (1)
-    // seqno (8)
-    // format (1)
-    // len_ns (4)
-    // namespace (len_ns)
-    // len_key (4)
-    // entries payload
-    // entries_count (4)
-    // digest (28)
+    /// Discharge the current chunk buffer to the writer and update the state.
+    ///
+    /// Note that this _must_ be called when the necessary state is available. Namely:
+    /// [`SclsWriter::prev_namespace`], [`SclsWriter::current_chunk`] and the respective namespace
+    /// entry in [`SclsWriter::ns_state`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Wire format field overflows
+    /// - I/O failures
+    fn flush_chunk(&mut self) -> Result<()> {
+        let Some(namespace) = &self.prev_namespace else {
+            unreachable!("must only be called when the namespace is set");
+        };
+
+        // Get the current chunk state and reset it (i.e., replace it with `None`)
+        let Some(chunk) = self.current_chunk.take() else {
+            unreachable!("must only be called when the current chunk is set");
+        };
+
+        let Some(ns_state) = self.ns_state.get_mut(namespace) else {
+            unreachable!("must only be called when the namespace state is set")
+        };
+
+        let len_ns = u32::try_from(namespace.len())
+            .map_err(|_| SclsError::WireLengthOverflow("namespace".into()))?;
+        let len_key = ns_state.key_len.unwrap(); // Safe (set in update_chunk)
+        let len_entries = u32::try_from(chunk.payload.len())
+            .map_err(|_| SclsError::WireLengthOverflow("entries".into()))?;
+
+        let len_record = [
+            1,           // Type
+            8,           // Sequence number
+            1,           // Format
+            4,           // Namespace length
+            len_ns,      // Namespace
+            4,           // Entry key length
+            len_entries, // Entries payload
+            4,           // Entries count
+            28,          // Digest
+        ]
+        .iter()
+        .try_fold(0u32, |acc, &x| acc.checked_add(x))
+        .ok_or(SclsError::WireLengthOverflow("record".into()))?;
+
+        // Discharge chunk wire format
+        self.output.write_all(&len_record.to_be_bytes())?;
+        self.output.write_all(&[RecordType::Chunk.to_byte()])?;
+        self.output.write_all(&self.chunk_seqno.to_be_bytes())?;
+        self.output.write_all(&[ChunkFormat::Raw.to_byte()])?; // Compression support forthcoming
+        self.output.write_all(&len_ns.to_be_bytes())?;
+        self.output.write_all(namespace.as_bytes())?;
+        self.output.write_all(&len_key.to_be_bytes())?;
+        self.output.write_all(&chunk.payload)?;
+        self.output.write_all(&chunk.entries.to_be_bytes())?;
+        self.output.write_all(chunk.hasher.as_digest().as_bytes())?;
+
+        // Update state (recall that we already reset the chunk state earlier)
+        self.chunk_seqno += 1;
+        ns_state.chunks += 1;
+        ns_state.entries += u64::from(chunk.entries);
+
+        Ok(())
+    }
 
     /// Finalise the SCLS output.
     ///
@@ -332,7 +392,10 @@ impl<W: Write> SclsWriter<W> {
     ///
     /// Returns an error if:
     /// - TODO
-    pub fn finalise(self) -> Result<()> {
+    pub fn finalise(mut self) -> Result<()> {
+        // Discharge the final chunk to the writer
+        self.flush_chunk()?;
+
         todo!()
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -433,3 +433,214 @@ impl<W: Write> SclsWriter<W> {
         todo!()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::reader::Record;
+    use crate::records::Entry;
+
+    use proptest::prelude::*;
+
+    #[test]
+    fn accept_same_namespace() -> Result<()> {
+        let buf = Vec::new();
+        let mut writer = SclsWriter::builder().output(buf).slot_no(0).build()?;
+
+        assert!(writer.write_entry("test", b"a", b"a").is_ok());
+        assert!(writer.write_entry("test", b"b", b"a").is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn accept_monotonic_namespace() -> Result<()> {
+        let buf = Vec::new();
+        let mut writer = SclsWriter::builder().output(buf).slot_no(0).build()?;
+
+        assert!(writer.write_entry("a", b"a", b"a").is_ok());
+        assert!(writer.write_entry("b", b"a", b"a").is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn forbid_decreasing_namespace() -> Result<()> {
+        let buf = Vec::new();
+        let mut writer = SclsWriter::builder().output(buf).slot_no(0).build()?;
+
+        assert!(writer.write_entry("b", b"a", b"a").is_ok());
+        let Err(err) = writer.write_entry("a", b"a", b"a") else {
+            panic!("descending namespace should be forbidden")
+        };
+
+        assert!(matches!(err, SclsError::NonMonotonicNamespace { .. }));
+
+        Ok(())
+    }
+
+    #[test]
+    fn forbid_previous_namespace() -> Result<()> {
+        let buf = Vec::new();
+        let mut writer = SclsWriter::builder().output(buf).slot_no(0).build()?;
+
+        assert!(writer.write_entry("a", b"a", b"a").is_ok());
+        assert!(writer.write_entry("b", b"a", b"a").is_ok());
+        let Err(err) = writer.write_entry("a", b"b", b"a") else {
+            panic!("descending namespace should be forbidden");
+        };
+
+        assert!(matches!(err, SclsError::NonMonotonicNamespace { .. }));
+
+        Ok(())
+    }
+
+    #[test]
+    fn accept_strictly_increasing_keys() -> Result<()> {
+        let buf = Vec::new();
+        let mut writer = SclsWriter::builder().output(buf).slot_no(0).build()?;
+
+        assert!(writer.write_entry("a", b"a", b"a").is_ok());
+        assert!(writer.write_entry("a", b"b", b"a").is_ok());
+        assert!(writer.write_entry("b", b"a", b"a").is_ok());
+        assert!(writer.write_entry("b", b"b", b"a").is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn forbid_equal_keys() -> Result<()> {
+        let buf = Vec::new();
+        let mut writer = SclsWriter::builder().output(buf).slot_no(0).build()?;
+
+        assert!(writer.write_entry("test", b"a", b"a").is_ok());
+        assert!(matches!(
+            writer.write_entry("test", b"a", b"a"),
+            Err(SclsError::NonStrictlyMonotonicKeys { .. })
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn forbid_decreasing_keys() -> Result<()> {
+        let buf = Vec::new();
+        let mut writer = SclsWriter::builder().output(buf).slot_no(0).build()?;
+
+        assert!(writer.write_entry("test", b"b", b"a").is_ok());
+        assert!(matches!(
+            writer.write_entry("test", b"a", b"a"),
+            Err(SclsError::NonStrictlyMonotonicKeys { .. })
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn key_order_resets_with_namespace() -> Result<()> {
+        let buf = Vec::new();
+        let mut writer = SclsWriter::builder().output(buf).slot_no(0).build()?;
+
+        assert!(writer.write_entry("a", b"b", b"a").is_ok());
+        assert!(writer.write_entry("b", b"a", b"a").is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn forbid_inconsistent_key_length_within_namespace() -> Result<()> {
+        let buf = Vec::new();
+        let mut writer = SclsWriter::builder().output(buf).slot_no(0).build()?;
+
+        assert!(writer.write_entry("test", b"a", b"a").is_ok());
+        assert!(matches!(
+            writer.write_entry("test", b"foo", b"a"),
+            Err(SclsError::InconsistentKeyLength { .. })
+        ));
+
+        Ok(())
+    }
+
+    // Strategy to generate valid (namespace, key, entry) sequences
+    prop_compose! {
+        fn valid_entry_writes()
+            (
+                // (Namespace, entry key) pairs will be correctly ordered in a BTreeSet.
+                // The entry key is limited to one byte to side-step the fixed key length per
+                // namespace constraint.
+                pairs in proptest::collection::btree_set(("[a-z]+", any::<u8>()), 1..=20),
+            )
+            (
+                values in proptest::collection::vec(
+                    proptest::collection::vec(any::<u8>(), 0..=16usize),
+                    pairs.len()..=pairs.len(),
+                ),
+                pairs in Just(pairs),
+            )
+        -> Vec<(String, Vec<u8>, Vec<u8>)> {
+            pairs.into_iter()
+                .zip(values)
+                .map(|((ns, key), value)| (ns, vec![key], value))
+                .collect()
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn chunk_roundtrip(entries in valid_entry_writes()) {
+            let mut buf = Vec::new();
+            let mut writer = SclsWriter::builder().output(&mut buf).slot_no(0).build()?;
+
+            let mut written_by_ns: BTreeMap<String, Vec<Entry>> = BTreeMap::new();
+            let mut read_by_ns: BTreeMap<String, Vec<Entry>> = BTreeMap::new();
+
+            for (namespace, key, value) in &entries {
+                // Group entries by namespace (correctly ordered)
+                written_by_ns.entry(namespace.clone())
+                    .or_default()
+                    .push(Entry { key: key.clone(), value: value.clone() });
+
+                writer.write_entry(namespace.as_str(), key, value)?;
+            }
+
+            // Flush the last chunk with a dummy namespace which is guaranteed to be monotonic (the
+            // strategy generates namespaces that match /[a-z]+/ and CJK characters are way beyond
+            // that range in Unicode). The chunk with this entry will never be flushed, by design.
+            writer.write_entry("最终", b"a", b"a")?;
+
+            let mut cursor = Cursor::new(buf.clone());
+            let header_first = matches!(Record::read_next(&mut cursor)?, Some(Record::Header(_)));
+            prop_assert!(header_first);
+
+            let mut seqno = 0;
+
+            while let Some(Record::Chunk(chunk)) = Record::read_next(&mut cursor)? {
+                let mut cursor = Cursor::new(buf.clone());
+
+                // Check ascending sequence number
+                prop_assert_eq!(chunk.seqno, seqno);
+                seqno += 1;
+
+                // Verify chunk digest
+                prop_assert!(chunk.verify(&mut cursor).is_ok());
+
+                // Build up entries by namespace
+                chunk.for_each_entry(&mut cursor, |reader, key_len, val_len| {
+                    let namespace = chunk.namespace.clone();
+                    let entry = Entry::materialise(reader, key_len, val_len)?;
+
+                    read_by_ns.entry(namespace)
+                        .or_default()
+                        .push(entry);
+
+                    Ok(())
+                })?;
+            }
+
+            // Check namespace entries match
+            prop_assert_eq!(read_by_ns, written_by_ns);
+        }
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,8 +1,10 @@
 //! SCLS file writing.
 
+use std::collections::BTreeMap;
 use std::io::Write;
 
 use crate::error::{Result, SclsError};
+use crate::hash::{Blake2b, MerkleTree};
 use crate::records::Header;
 
 /// Default tool name.
@@ -12,6 +14,7 @@ pub const DEFAULT_TOOL: &str = "cardano-scrawls";
 pub const DEFAULT_MAX_CHUNK_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
 
 /// SclsWriter builder.
+#[derive(Debug)]
 pub struct SclsWriterBuilder<W: Write> {
     output: Option<W>,
     slot_no: Option<u64>,
@@ -99,7 +102,54 @@ impl<W: Write> Default for SclsWriterBuilder<W> {
     }
 }
 
+/// Namespace state tracking.
+#[derive(Debug)]
+struct NamespaceState {
+    /// Number of chunks in the namespace
+    chunks: u64,
+
+    /// Number of entries in the namespace
+    entries: u64,
+
+    /// Merkle tree for namespace
+    merkle: MerkleTree,
+}
+
+impl NamespaceState {
+    fn new() -> Self {
+        Self {
+            chunks: 0,
+            entries: 0,
+            merkle: MerkleTree::new(),
+        }
+    }
+}
+
+/// Chunk state tracking.
+#[derive(Debug)]
+struct ChunkState {
+    /// Serialised entries payload
+    payload: Vec<u8>,
+
+    /// Chunk digest
+    digest: Blake2b,
+
+    /// Number of entries in the chunk
+    entries: u32,
+}
+
+impl ChunkState {
+    fn new() -> Self {
+        Self {
+            payload: Vec::new(),
+            digest: Blake2b::new_raw(),
+            entries: 0,
+        }
+    }
+}
+
 /// A writer for SCLS files.
+#[derive(Debug)]
 pub struct SclsWriter<W> {
     /// Output sink
     output: W,
@@ -116,12 +166,22 @@ pub struct SclsWriter<W> {
     /// Ideal maximum chunk size (bytes)
     max_chunk_size: usize,
 
+    /* State tracking */
     /// Previously written namespace
     prev_namespace: Option<String>,
 
     /// Previously written namespace entry key
     // NOTE Reset this to `None` when `prev_namespace` changes
     prev_ns_entry_key: Option<Vec<u8>>,
+
+    /// Chunk sequence number
+    chunk_seqno: u64,
+
+    /// Chunk state
+    current_chunk: Option<ChunkState>,
+
+    /// Namespace state
+    ns_state: BTreeMap<String, NamespaceState>,
 }
 
 impl<W: Write> SclsWriter<W> {
@@ -140,7 +200,43 @@ impl<W: Write> SclsWriter<W> {
     ///   keys in the given namespace
     /// - TODO
     pub fn write_entry(&mut self, namespace: &str, key: &[u8], value: &[u8]) -> Result<()> {
-        todo!()
+        // SclsWriter::write_entry - namespace, key, value
+        // - [ ] Check namespace:
+        //   - [ ] Previous None =>
+        //     - [ ] Set previous namespace
+        //     - [ ] Create new ns_state
+        //   - [ ] Check monotonicity if changed:
+        //     - [ ] OK =>
+        //       - [ ] Flush chunk (must exist)
+        //       - [ ] Update previous namespace
+        //       - [ ] Reset previous key
+        //       - [ ] Create new ns_state
+        //     - [ ] Fail => Error
+        //  - [ ] Check entry key
+        //    - [ ] Previous None =>
+        //      - [ ] Set previous key
+        //    - Check strict monotonicity:
+        //      - [ ] OK => Update previous key
+        //      - [ ] Fail => Error
+        //  - [ ] Is previous chunk, if it exists, oversized => Flush chunk
+        //  - [ ] Is current chunk None => Create new chunk
+        //  - [ ] Build chunk
+        //
+        //  SclsWriter::build_chunk - namespace, key, value
+        //  - [ ] Compute entry digest
+        //  - [ ] Update chunk digest accumulator
+        //  - [ ] Add leaf to namespace Merkle tree
+        //  - [ ] Serialise entry into chunk buffer
+        //
+        //  NOTE: Finalise will have to call build_chunk to empty what's left in the buffer
+        //
+        // ChunkState::write - writer (SclsWriter.output), seqno (SclsWriter.chunk_seqno), namespace (SclsWriter.prev_namespace)
+        // OR SclsWriter::flush_chunk - chunk state [cleaner]
+        // - [ ] Discharge chunk wire format to writer
+        // - [ ] Increment chunk_seqno
+        // - [ ] Update ns_state[namespace].{chunks, entries}
+        // - [ ] Reset current_chunk to None
+        Ok(())
     }
 
     /// Finalise the SCLS output.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -81,6 +81,9 @@ impl<W: Write> SclsWriterBuilder<W> {
             max_chunk_size: self.max_chunk_size,
             prev_namespace: None,
             prev_ns_entry_key: None,
+            chunk_seqno: 0,
+            current_chunk: None,
+            ns_state: BTreeMap::new(),
         };
 
         let header = Header::current();
@@ -105,6 +108,9 @@ impl<W: Write> Default for SclsWriterBuilder<W> {
 /// Namespace state tracking.
 #[derive(Debug)]
 struct NamespaceState {
+    /// Namespace key length
+    key_len: Option<u32>,
+
     /// Number of chunks in the namespace
     chunks: u64,
 
@@ -118,6 +124,7 @@ struct NamespaceState {
 impl NamespaceState {
     fn new() -> Self {
         Self {
+            key_len: None,
             chunks: 0,
             entries: 0,
             merkle: MerkleTree::new(),
@@ -212,23 +219,21 @@ impl<W: Write> SclsWriter<W> {
         //       - [ ] Reset previous key
         //       - [ ] Create new ns_state
         //     - [ ] Fail => Error
-        //  - [ ] Check entry key
-        //    - [ ] Previous None =>
-        //      - [ ] Set previous key
-        //    - Check strict monotonicity:
-        //      - [ ] OK => Update previous key
-        //      - [ ] Fail => Error
-        //  - [ ] Is previous chunk, if it exists, oversized => Flush chunk
-        //  - [ ] Is current chunk None => Create new chunk
-        //  - [ ] Build chunk
+        // - [ ] Check entry key
+        //   - [ ] Previous None =>
+        //     - [ ] Set previous key
+        //   - Check strict monotonicity:
+        //     - [ ] OK => Update previous key
+        //     - [ ] Fail => Error
+        // - [ ] Is previous chunk, if it exists, oversized => Flush chunk
+        // - [ ] Is current chunk None => Create new chunk
+        // - [x] Update chunk
         //
-        //  SclsWriter::build_chunk - namespace, key, value
-        //  - [ ] Compute entry digest
-        //  - [ ] Update chunk digest accumulator
-        //  - [ ] Add leaf to namespace Merkle tree
-        //  - [ ] Serialise entry into chunk buffer
-        //
-        //  NOTE: Finalise will have to call build_chunk to empty what's left in the buffer
+        // SclsWriter::update_chunk - namespace, key, value
+        // - [x] Compute entry digest
+        // - [x] Update chunk digest accumulator
+        // - [x] Add leaf to namespace Merkle tree
+        // - [x] Serialise entry into chunk buffer
         //
         // ChunkState::write - writer (SclsWriter.output), seqno (SclsWriter.chunk_seqno), namespace (SclsWriter.prev_namespace)
         // OR SclsWriter::flush_chunk - chunk state [cleaner]
@@ -236,8 +241,90 @@ impl<W: Write> SclsWriter<W> {
         // - [ ] Increment chunk_seqno
         // - [ ] Update ns_state[namespace].{chunks, entries}
         // - [ ] Reset current_chunk to None
+        //
+        //  NOTE: Finalise will have to call flush_chunk to empty what's left in the buffer
+
+        self.update_chunk(key, value)
+    }
+
+    /// Update the chunk that is currently being built with the next entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The entry, its key or its value has length greater than 2^32 bytes
+    /// - Entry key length is inconsistent within the same namespace
+    fn update_chunk(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
+        let Some(namespace) = &self.prev_namespace else {
+            unreachable!("must only be called when the namespace is set");
+        };
+
+        let Some(chunk) = &mut self.current_chunk else {
+            unreachable!("must only be called when the current chunk is set");
+        };
+
+        let Some(ns_state) = self.ns_state.get_mut(namespace) else {
+            unreachable!("must only be called when the namespace state is set")
+        };
+
+        // Set and check the key length, as necessary
+        match ns_state.key_len {
+            Some(key_len) => {
+                // Key length consistency check
+                if key.len() != key_len as usize {
+                    return Err(SclsError::InconsistentKeyLength {
+                        namespace: namespace.clone(),
+                        expected: key_len as usize,
+                        found: key.len(),
+                    });
+                }
+            }
+
+            None => {
+                // Checked truncation
+                let key_len = u32::try_from(key.len()).map_err(|_| SclsError::EntryOverflow)?;
+                ns_state.key_len = Some(key_len);
+            }
+        };
+
+        // Compute entry digest
+        let entry_digest = Blake2b::new_leaf()
+            .update(namespace.as_bytes())
+            .update(key)
+            .update(value)
+            .as_digest();
+
+        // Update chunk digest and namespace Merkle tree
+        chunk.digest.update(entry_digest.as_bytes());
+        ns_state.merkle.add_leaf(entry_digest);
+
+        // Serialise entry
+        let entry_len = u32::try_from(
+            key.len()
+                .checked_add(value.len())
+                .ok_or(SclsError::EntryOverflow)?,
+        )
+        .map_err(|_| SclsError::EntryOverflow)?;
+
+        chunk.entries += 1;
+        chunk.payload.extend_from_slice(&entry_len.to_be_bytes());
+        chunk.payload.extend_from_slice(key);
+        chunk.payload.extend_from_slice(value);
+
         Ok(())
     }
+
+    // TODO: Flush chunk
+    // len_record (4) = 1 + 8 + 1 + 4 + len_ns + 4 + len(entries) + 4 + 28
+    // type byte (1)
+    // seqno (8)
+    // format (1)
+    // len_ns (4)
+    // namespace (len_ns)
+    // len_key (4)
+    // entries payload
+    // entries_count (4)
+    // digest (28)
 
     /// Finalise the SCLS output.
     ///

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -118,7 +118,7 @@ struct NamespaceState {
     /// Number of entries in the namespace
     entries: u64,
 
-    /// Merkle tree for namespace
+    /// Merkle tree fornamespace
     merkle: MerkleTree,
 }
 
@@ -559,6 +559,67 @@ mod tests {
             writer.write_entry("test", b"foo", b"a"),
             Err(SclsError::InconsistentKeyLength { .. })
         ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn chunk_size_below_threshold() -> Result<()> {
+        let mut buf = Vec::new();
+        let mut writer = SclsWriter::builder()
+            .output(&mut buf)
+            .slot_no(0)
+            .max_chunk_size(12)
+            .build()?;
+
+        // Entry length: len_body(4) + key(1) + value(1) = 6 bytes
+        writer.write_entry("test", b"a", b"a")?; // +6 bytes
+        writer.write_entry("test", b"b", b"a")?; // +6 bytes
+
+        // At threshold, no chunk should have been written
+        let mut cursor = Cursor::new(buf.clone());
+        assert!(matches!(
+            Record::read_next(&mut cursor)?,
+            Some(Record::Header(_))
+        ));
+        assert!(Record::read_next(&mut cursor)?.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn chunk_size_above_threshold() -> Result<()> {
+        let key = b"a";
+        let value = b"this is an oversized entry";
+
+        let mut buf = Vec::new();
+        let mut writer = SclsWriter::builder()
+            .output(&mut buf)
+            .slot_no(0)
+            .max_chunk_size(12)
+            .build()?;
+
+        writer.write_entry("test", key, value)?; // +31 bytes
+        writer.write_entry("test", b"b", b"a")?; // +6 bytes (to force flush)
+
+        // We should have one chunk with the oversized record
+        let mut cursor = Cursor::new(buf.clone());
+        assert!(matches!(
+            Record::read_next(&mut cursor)?,
+            Some(Record::Header(_))
+        ));
+        let Some(Record::Chunk(chunk)) = Record::read_next(&mut cursor)? else {
+            panic!("expected chunk");
+        };
+        assert!(Record::read_next(&mut cursor)?.is_none());
+
+        chunk.for_each_entry(&mut cursor, |reader, key_len, val_len| {
+            let entry = Entry::materialise(reader, key_len, val_len)?;
+            assert_eq!(entry.key, key);
+            assert_eq!(entry.value, value);
+
+            Ok(())
+        })?;
 
         Ok(())
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,5 +1,6 @@
 //! SCLS file writing.
 
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -206,44 +207,75 @@ impl<W: Write> SclsWriter<W> {
     /// - The namespace is not the same or bytewise ascending from previously written namespaces
     /// - The entry key is not strictly lexicographically monotonic for previously written entry
     ///   keys in the given namespace
-    /// - TODO
+    /// - The entry, its key or its value has length greater than 2^32 bytes
+    /// - Entry key length is inconsistent within the same namespace
+    /// - Wire format field overflows
+    /// - I/O failures
     pub fn write_entry(&mut self, namespace: &str, key: &[u8], value: &[u8]) -> Result<()> {
-        // SclsWriter::write_entry - namespace, key, value
-        // - [ ] Check namespace:
-        //   - [ ] Previous None =>
-        //     - [ ] Set previous namespace
-        //     - [ ] Create new ns_state
-        //   - [ ] Check monotonicity if changed:
-        //     - [ ] OK =>
-        //       - [ ] Flush chunk (must exist)
-        //       - [ ] Update previous namespace
-        //       - [ ] Reset previous key
-        //       - [ ] Create new ns_state
-        //     - [ ] Fail => Error
-        // - [ ] Check entry key
-        //   - [ ] Previous None =>
-        //     - [ ] Set previous key
-        //   - Check strict monotonicity:
-        //     - [ ] OK => Update previous key
-        //     - [ ] Fail => Error
-        // - [ ] Is previous chunk, if it exists, oversized => Flush chunk
-        // - [ ] Is current chunk None => Create new chunk
-        // - [x] Update chunk
-        //
-        // SclsWriter::update_chunk - namespace, key, value
-        // - [x] Compute entry digest
-        // - [x] Update chunk digest accumulator
-        // - [x] Add leaf to namespace Merkle tree
-        // - [x] Serialise entry into chunk buffer
-        //
-        // ChunkState::write - writer (SclsWriter.output), seqno (SclsWriter.chunk_seqno), namespace (SclsWriter.prev_namespace)
-        // OR SclsWriter::flush_chunk - chunk state [cleaner]
-        // - [x] Discharge chunk wire format to writer
-        // - [x] Increment chunk_seqno
-        // - [x] Update ns_state[namespace].{chunks, entries}
-        // - [x] Reset current_chunk to None
-        //
-        // [x] NOTE: Finalise will have to call flush_chunk to empty what's left in the buffer
+        // Check and update (if necessary) namespace state
+        match &self.prev_namespace {
+            None => {
+                self.prev_namespace = Some(namespace.to_string());
+                self.ns_state
+                    .insert(namespace.to_string(), NamespaceState::new());
+            }
+
+            Some(prev_namespace) => {
+                let order = prev_namespace.as_str().cmp(namespace);
+                match order {
+                    // No namespace change: nothing to do
+                    Ordering::Equal => {}
+
+                    // New namespace is monotonically increasing: flush chunk and reset state
+                    Ordering::Less => {
+                        self.flush_chunk()?;
+                        self.prev_namespace = Some(namespace.to_string());
+                        self.prev_ns_entry_key = None;
+                        self.ns_state
+                            .insert(namespace.to_string(), NamespaceState::new());
+                    }
+
+                    // Non-monotonic namespace
+                    Ordering::Greater => {
+                        return Err(SclsError::NonMonotonicNamespace {
+                            previous: prev_namespace.clone(),
+                            found: namespace.to_string(),
+                        });
+                    }
+                };
+            }
+        }
+
+        // Check and update (if necessary) key entry state
+        match &self.prev_ns_entry_key {
+            None => {
+                self.prev_ns_entry_key = Some(key.to_vec());
+            }
+
+            Some(prev_key) => {
+                // Strict monotonicity check
+                if prev_key.as_slice() >= key {
+                    return Err(SclsError::NonStrictlyMonotonicKeys {
+                        namespace: namespace.to_string(),
+                    });
+                }
+
+                self.prev_ns_entry_key = Some(key.to_vec());
+            }
+        }
+
+        // Flush any existing chunk that's reached the size limit
+        // Note that this resets the current chunk (see SclsWriter::flush_chunk)
+        if let Some(chunk) = &self.current_chunk
+            && chunk.payload.len() >= self.max_chunk_size
+        {
+            self.flush_chunk()?;
+        }
+
+        // Create a new chunk, if required
+        if self.current_chunk.is_none() {
+            self.current_chunk = Some(ChunkState::new());
+        }
 
         self.update_chunk(key, value)
     }
@@ -393,8 +425,10 @@ impl<W: Write> SclsWriter<W> {
     /// Returns an error if:
     /// - TODO
     pub fn finalise(mut self) -> Result<()> {
-        // Discharge the final chunk to the writer
-        self.flush_chunk()?;
+        // Discharge the final chunk, if there is one, to the writer
+        if self.current_chunk.is_some() {
+            self.flush_chunk()?;
+        }
 
         todo!()
     }


### PR DESCRIPTION
Depends on #23

- Chunk writing and state tracking
- Invariant tests: namespace/entry key ordering and size threshold constraints
- Round-trip property test

> [!NOTE]
> The CI will fail because there is still some unused code. FWIW, the tests pass on my machine :sweat_smile: 
> ```
> $ cargo nextest run writer
> + command cargo nextest run writer
> warning: fields `slot_no`, `tool`, and `comment` are never read
>    --> src/writer.rs:166:5
>     |
> 161 | pub struct SclsWriter<W> {
>     |            ---------- fields in this struct
> ...
> 166 |     slot_no: u64,
>     |     ^^^^^^^
> ...
> 169 |     tool: String,
>     |     ^^^^
> ...
> 172 |     comment: Option<String>,
>     |     ^^^^^^^
>     |
>     = note: `SclsWriter` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
>     = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
> 
> warning: `cardano-scrawls` (lib) generated 1 warning
> warning: `cardano-scrawls` (lib test) generated 1 warning (1 duplicate)
>     Finished `test` profile [unoptimized + debuginfo] target(s) in 0.04s
> ────────────
>  Nextest run ID 44052a1d-f5ce-4522-8900-6fa1c34fac07 with nextest profile: default
>     Starting 12 tests across 1 binary (40 tests skipped)
>         PASS [   0.005s] cardano-scrawls writer::tests::accept_monotonic_namespace
>         PASS [   0.005s] cardano-scrawls writer::tests::accept_same_namespace
>         PASS [   0.006s] cardano-scrawls writer::tests::chunk_size_below_threshold
>         PASS [   0.007s] cardano-scrawls writer::tests::accept_strictly_increasing_keys
>         PASS [   0.007s] cardano-scrawls writer::tests::chunk_size_above_threshold
>         PASS [   0.007s] cardano-scrawls writer::tests::forbid_decreasing_keys
>         PASS [   0.008s] cardano-scrawls writer::tests::forbid_decreasing_namespace
>         PASS [   0.005s] cardano-scrawls writer::tests::forbid_equal_keys
>         PASS [   0.004s] cardano-scrawls writer::tests::forbid_previous_namespace
>         PASS [   0.004s] cardano-scrawls writer::tests::forbid_inconsistent_key_length_within_namespace
>         PASS [   0.005s] cardano-scrawls writer::tests::key_order_resets_with_namespace
>         PASS [   0.349s] cardano-scrawls writer::tests::chunk_roundtrip
> ────────────
>      Summary [   0.349s] 12 tests run: 12 passed, 40 skipped
> ```